### PR TITLE
Agrego nombre del producto en la descripción a enviar a Cybersource

### DIFF
--- a/app/code/community/Todopago/Modulodepago2/Model/Cybersource/Cybersource.php
+++ b/app/code/community/Todopago/Modulodepago2/Model/Cybersource/Cybersource.php
@@ -116,7 +116,7 @@ abstract class Todopago_Modulodepago2_Model_Cybersource_Cybersource extends Mage
 			}
 ////
 			
-			$_description = $p->getDescription() . "  " . $p->getShortDescription();
+			$_description = $p->getName() . " " . $p->getDescription() . "  " . $p->getShortDescription();
 			$_description = $this->getField($_description);
 			$_description = trim($_description);
 			$_description = substr($_description, 0,15);


### PR DESCRIPTION
Dado que TodoPago rechaza el pago en el momento de redirigir al Gateway si CSITPRODUCTDESCRIPTION está en blanco, y que description y short_description no son obligatorios, agrego el name que sí lo es para garantizar que el campo no esté vacío