### PR TITLE
Update agreements.phtml

### DIFF
--- a/app/design/frontend/base/default/template/todopagomodulodepago/checkout/agreements.phtml
+++ b/app/design/frontend/base/default/template/todopagomodulodepago/checkout/agreements.phtml
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @see Mage_Checkout_Block_Agreements
+ */
+?>
+
+<?php if (!$this->getAgreements()) return; ?>
+<form action="" id="checkout-agreements" onsubmit="return false;">
+<ol class="checkout-agreements">
+<?php foreach ($this->getAgreements() as $_a): ?>
+    <li>
+        <div class="agreement-content"<?php echo ($_a->getContentHeight() ? ' style="height:' . $_a->getContentHeight() . '"' : '')?>>
+            <?php if ($_a->getIsHtml()):?>
+                <?php echo $_a->getContent() ?>
+            <?php else:?>
+                <?php echo nl2br($this->htmlEscape($_a->getContent())) ?>
+            <?php endif; ?>
+        </div>
+        <p class="agree">
+            <input type="checkbox" id="agreement-<?php echo $_a->getId()?>" name="agreement[<?php echo $_a->getId()?>]" value="1" title="<?php echo $this->htmlEscape($_a->getCheckboxText()) ?>" class="checkbox" /><label for="agreement-<?php echo $_a->getId()?>"><?php echo $_a->getIsHtml() ? $_a->getCheckboxText() : $this->htmlEscape($_a->getCheckboxText()) ?></label>
+        </p>
+    </li>
+<?php endforeach ?>
+</ol>
+</form>


### PR DESCRIPTION
No entiendo el motivo por el cual se dejó este archivo en blanco y tampoco se especificó en ninguna parte. Pero al habilitar todas las opciones de Magento Standard para establecer Términos y condiciones a la hora de completar un checkout este no te permitía avanzar hasta que los términos y condiciones no se acepten lo cual generaba un bloqueo al proceso.